### PR TITLE
Compare hitstop issue without overriding hitstop time scale 

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1718,7 +1718,7 @@ Transform:
   m_GameObject: {fileID: 301924010}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.1594682, y: 3.93042, z: -10}
+  m_LocalPosition: {x: 1.2644325, y: 3.93007, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -17423,7 +17423,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: '::'
   devConsole: {fileID: 11400000, guid: 152ab5dc1f46418458449a6caea414b5, type: 2}
-  hitStop: {fileID: 0}
+  hitStop: {fileID: 249670388}
 --- !u!4 &593616986
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/General/HitStop.cs.meta
+++ b/Assets/Scripts/General/HitStop.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 11094706c3536b844be4d00d56b3a288
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World/DeveloperConsole.cs
+++ b/Assets/Scripts/World/DeveloperConsole.cs
@@ -13,6 +13,5 @@ public class DeveloperConsole : MonoBehaviour
             if (!hitStop.isWaiting) Time.timeScale = devConsole.timeScale;
         }
         Application.targetFrameRate = devConsole.targetFrameRate;
-        Time.timeScale = devConsole.timeScale;
     }
 }

--- a/Assets/Variables/DevConsole.asset
+++ b/Assets/Variables/DevConsole.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: DevConsole
   m_EditorClassIdentifier: Assembly-CSharp::DevConsole
   cheatsOn: 1
-  overrideTime: 0
-  timeScale: 0.2
-  targetFrameRate: 10
+  overrideTime: 1
+  timeScale: 1
+  targetFrameRate: 15
   npcInteractableRange: 2

--- a/Assets/Variables/PlayerData.asset
+++ b/Assets/Variables/PlayerData.asset
@@ -21,13 +21,13 @@ MonoBehaviour:
   dashDuration: 0.2
   dashDelay: 0
   dashCooldown: 0.1
-  dashCooldownTimer: -3.7599967
+  dashCooldownTimer: -202.64647
   dashForce: 30
   jumpForce: 15
   maxFallSpeed: 30
-  hp: -2350
+  hp: -3190
   damage: 10
-  hitStopDuration: 0.09
+  hitStopDuration: 0.5
   attackHitboxDelay: 0
   attackHitboxDuration: 0.1
   isJumping: 0
@@ -35,3 +35,4 @@ MonoBehaviour:
   isGrounded: 1
   isInvincible: 0
   isMovementDisabled: 0
+  isAggroed: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.2.1f1
-m_EditorVersionWithRevision: 6000.2.1f1 (55300504c302)
+m_EditorVersion: 6000.2.5f1
+m_EditorVersionWithRevision: 6000.2.5f1 (43d04cd1df69)


### PR DESCRIPTION
Differences to note:
I am using 6000.2.5f1, project was in 6000.2.1f1
Removed line in DeveloperConsole.cs where timescale of histop was being overriden (basically there would be no hitstop at all since devconsole would constantly update the timescale to whatever is being set)
Ensure that DevConsole gameobject holds a reference to the hitstop script to check if isWaiting is true